### PR TITLE
truncate job name length to 63 characters

### DIFF
--- a/controllers/fipsetup/fipsetup.go
+++ b/controllers/fipsetup/fipsetup.go
@@ -2,6 +2,7 @@ package fipsetup
 
 import (
 	"context"
+	"crypto/md5"
 	"fmt"
 
 	"github.com/samcday/hcloud-fip-k8s/api/v1alpha1"
@@ -97,8 +98,17 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	return reconcile.Result{}, nil
 }
 
+func (r *Reconciler) hashNodeName(nodeName string) string {
+	hash := md5.Sum([]byte(nodeName))
+	return fmt.Sprintf("%x", hash)[:8]
+}
+
+func (r *Reconciler) getJobName(jobType string, fip string, node *corev1.Node) string {
+	return fmt.Sprintf("fip-%s-%s-%s", jobType, fip, r.hashNodeName(node.Name))[:63]
+}
+
 func (r *Reconciler) getJob(ctx context.Context, jobType string, node *corev1.Node, fip string) (*batchv1.Job, error) {
-	jobName := fmt.Sprintf("fip-%s-%s-%s", jobType, fip, node.Name)[:63]
+	jobName := r.getJobName(jobType, fip, node)
 
 	job := &batchv1.Job{}
 	err := r.Get(ctx, types.NamespacedName{Namespace: r.FloatingIP.JobNamespace, Name: jobName}, job)
@@ -113,7 +123,7 @@ func (r *Reconciler) createJob(ctx context.Context, jobType string, fip string, 
 	job := batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: r.FloatingIP.JobNamespace,
-			Name:      fmt.Sprintf("fip-%s-%s-%s", jobType, fip, node.Name),
+			Name:      r.getJobName(jobType, fip, node),
 		},
 		Spec: *jobSpec,
 	}


### PR DESCRIPTION
Hey @samcday,

thank you for this useful controller! I noticed an issue for nodes with a long name. The setup job will fail to create:
```
{"level":"error","ts":"2025-08-18T06:50:55.940Z","logger":"controller.node","msg":"Reconciler error","reconciler group":"","reconciler kind":"Node","name":"myproject-nod
epool-fsn1-cax31-c5hnw-ggj22","namespace":"","error":"Job.batch \"fip-setup-x.xx.xx.xxx-myproject-nodepool-fsn1-cax31-c5hnw-ggj22\" is invalid: spec.template.labels: Inv
alid value: \"fip-setup-x.xx.xx.xxx-myproject-nodepool-fsn1-cax31-c5hnw-ggj22\": must be no more than 63 characters","stacktrace":"sigs.k8s.io/controller-runtime/pkg/int
ernal/controller.(*Controller).processNextWorkItem\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.0/pkg/internal/controller/controller.go:266\nsigs.k8s.io/controller-
runtime/pkg/internal/controller.(*Controller).Start.func2.2\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.0/pkg/internal/controller/controller.go:227"}
```

I implemented a simple fix, that truncates the name to 63 characters.